### PR TITLE
Fix logic error in streamed JSON object parsing

### DIFF
--- a/core/llm/llms/Ollama.ts
+++ b/core/llm/llms/Ollama.ts
@@ -123,6 +123,7 @@ class Ollama extends BaseLLM {
       buffer += value;
       // Split the buffer into individual JSON chunks
       const chunks = buffer.split("\n");
+
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
         if (chunk.trim() !== "") {
@@ -161,6 +162,7 @@ class Ollama extends BaseLLM {
       buffer += value;
       // Split the buffer into individual JSON chunks
       const chunks = buffer.split("\n");
+      buffer = chunks.pop() ?? '';
       for (let i = 0; i < chunks.length; i++) {
         const chunk = chunks[i];
         if (chunk.trim() !== "") {
@@ -179,8 +181,6 @@ class Ollama extends BaseLLM {
           }
         }
       }
-      // Assign the last chunk to the buffer
-      buffer = chunks[chunks.length - 1];
     }
   }
 }


### PR DESCRIPTION
buffer becomes any character after `\n`, as anything before `\n` should be considered a valid JSON object